### PR TITLE
Run PhantomJS binary from PATH rather than absolute path

### DIFF
--- a/phantom.go
+++ b/phantom.go
@@ -55,7 +55,7 @@ func NewPhantom() Phantomer {
 	phantom := &Phantom{
 		userAgent:     "Mozilla/5.0+(compatible;+Baiduspider/2.0;++http://www.baidu.com/search/spider.html)",
 		pageEncode:    "utf-8",
-		phantomjsPath: GOPATH + "/src/github.com/k4s/phantomgo/phantomjs/phantomjs",
+		phantomjsPath: GOPATH + "phantomjs",
 	}
 	//if the javascript file is no exist,creat it
 	if !phantom.Exist(GET_JS_FILE_NAME) {

--- a/phantom.go
+++ b/phantom.go
@@ -55,7 +55,7 @@ func NewPhantom() Phantomer {
 	phantom := &Phantom{
 		userAgent:     "Mozilla/5.0+(compatible;+Baiduspider/2.0;++http://www.baidu.com/search/spider.html)",
 		pageEncode:    "utf-8",
-		phantomjsPath: GOPATH + "phantomjs",
+		phantomjsPath: "phantomjs",
 	}
 	//if the javascript file is no exist,creat it
 	if !phantom.Exist(GET_JS_FILE_NAME) {


### PR DESCRIPTION
I really like this package, but I don't like how it includes the PhantomJS binary. I think this is a great idea though so I want to try and use it in a website. So, I changed the phantomjsPath to simply "phantomjs" meaning it gets executed by searching the environment's PATH variable. I have phantom installed in /usr/local/bin which is a part of my path, but in other machines it might be installed somewhere else, so using the absolute path doesn't make sense. Also, you don't want to have to be responsible for maintaining the PhantomJS library in the repository, or for including a binary for every architecture.